### PR TITLE
Fix DataFrame lookup for chi-squared calculation.

### DIFF
--- a/report.py
+++ b/report.py
@@ -893,7 +893,7 @@ class report(object):
         # Only calculate reduced chi squared to the specified flux limit
         if limit_chi is not None:
             idx = np.where(df['logS'] > np.log10(limit_chi))[0]
-            df_idx = df.loc[idx]
+            df_idx = df.iloc[idx]
             red_chi_sq = calc_red_chi_sq(df_idx['logCounts'], df_idx['logS'], df_idx['logErrDown'])
         else:
             red_chi_sq = calc_red_chi_sq(df['logCounts'], df['logS'], df['logErrDown'])


### PR DESCRIPTION
The `DataFrame` object representing the source counts was being referenced using its `.loc` parameter, which looks up the object by label. Instead do the lookup using `.iloc` which looks up by index (as returned by the `np.where` call on the previous line).

Previously the lookup by label could cause lookups to nonexistent labels - which is deprecated in Pandas (see: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike ). The labels don't necessarily correspond to the desired indices since the `DataFrame` has elements removed on L858.