### PR TITLE
Change calls to matplotlib functions to remove DeprecationWarnings

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -262,7 +262,7 @@ def plot_spectra(freqs, fluxes, errs, models, names, params, param_errs, rcs,
     ax.yaxis.set_minor_formatter(ticker.NullFormatter())
     ax.xaxis.set_major_formatter(ticker.FuncFormatter(ticks_format_freq))
     ax.yaxis.set_major_formatter(ticker.FuncFormatter(ticks_format_flux))
-    ax.grid(b=True, which='minor', color='w', linewidth=0.5)
+    ax.grid(visible=True, which='minor', color='w', linewidth=0.5)
 
     # Plot flux measurements
     plt.errorbar(freqs, fluxes, yerr=errs, linestyle='none', marker='.', c='r', zorder=15)

--- a/report.py
+++ b/report.py
@@ -689,14 +689,14 @@ class report(object):
         # Get non-nan data shared between each used axis as a numpy array
         x, y, c, indices = self.shared_indices(xaxis, yaxis=ratio)
         plt.loglog()
-        plt.gca().grid(b=True, which='minor', color='w', linewidth=0.5)
+        plt.gca().grid(visible=True, which='minor', color='w', linewidth=0.5)
 
         # Hack to overlay resolved sources in red
         xres, yres = xaxis[self.cat.resolved], ratio[self.cat.resolved]
         markers = self.markers.copy()
         markers['color'] = 'r'
         markers.pop('s')
-        data, = plt.plot(xres, yres, 'o', zorder=50, **markers)
+        data, = plt.plot(xres, yres, zorder=50, **markers)
         leg_labels = ['Resolved', 'Unresolved']
 
         # Derive the statistics of y and store in string
@@ -1244,8 +1244,8 @@ class report(object):
                 elif c is None:
                     markers = self.markers.copy()
                     markers.pop('s')
-                    ax.plot(x, y, 'o', zorder=20, alpha=0.0, **markers)
-                    data, = ax.plot(x, y, 'o', **markers)
+                    ax.plot(x, y, zorder=20, alpha=0.0, **markers)
+                    data, = ax.plot(x, y, **markers)
                     handles.append(data)
                 # Plot scatter of data points with colour axis
                 else:
@@ -1590,7 +1590,7 @@ class report(object):
             # Get non-nan data shared between each used axis as a numpy array
             x, y, c, indices = self.shared_indices('SNR', yaxis=ratio)
             plt.loglog()
-            plt.gca().grid(b=True, which='minor', color='w', linewidth=0.5)
+            plt.gca().grid(visible=True, which='minor', color='w', linewidth=0.5)
 
             # Derive the ratio statistics and store in string to append to plot
             ratio_med, ratio_mean, ratio_std, ratio_err, ratio_mad = get_stats(y)


### PR DESCRIPTION
The b=True argument to plt.grid is removed in matplotlib=3.7 and replaced with visible=True, this change is compatible with the currently pinned matplotlib=3.3.4.
Remove the explicit 'o' marker specification in calls to plot, this is passed to these functions already by the 'markers' kwargs.